### PR TITLE
Small cleanups and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This module will manage the pattern databases of *syslog-ng* by using existing f
 
 Depending on the top-level configuration variables `$base_dir` and `$temp_dir`, this module will manage and execute the following elements in order:
 
-0. (OPTIONAL) Manage package `syslog-ng`
+0. (OPTIONAL) Manage package `syslog-ng` and remove the default syslog daemon (usually rsyslog)
 1. Manage `$base_dir/etc/syslog-ng/patterndb.d` recursively
 2. Manage the contents of the above directory using [existing](#defined-type-patterndbrawruleset) or [generated](#defined-type-patterndbsimpleruleset) patterndb *ruleset* files
 3. Merge the contents of the latter using `pdbtool` into a temporary file `${temp_dir}/syslog-ng/patterndb/${parser}.xml` where `$parser` is the name of the *patterndb* (you can have as many as you want, *e.g.* for *staged parsing*.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,16 +14,9 @@ class patterndb (
   validate_array($syslogng_modules)
 # package
   if $manage_package {
-    if is_string($package_name) {
-      $real_package_name = $package_name
-    } else {
-      case $::osfamily {
-        'RedHat': { $real_package_name = 'syslog-ng' }
-        'Debian': { $real_package_name = 'syslog-ng' }
-        default: { fail("unsupported osfamily: ${::osfamily}") }
-      }
+    class { '::patterndb::install':
+        package_name => $package_name,
     }
-    ensure_resource ( 'package', $real_package_name, { 'ensure' => 'installed' })
   }
   ensure_resource ( 'file', $temp_dir, { ensure => directory } )
   ensure_resource ( 'file', "${base_dir}/etc", { ensure => 'directory' } )

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,24 @@
+#
+# == Class: patterndb::install
+#
+# Ensure that the default syslog is uninstalled and that syslog-ng is installed.
+#
+class patterndb::install (
+    $package_name
+) inherits patterndb::params
+{
+  if is_string($package_name) {
+    $real_package_name = $package_name
+  } else {
+    $real_package_name = $::patterndb::params::syslog_ng_package_name
+  }
+
+  package { $::patterndb::params::default_syslog_package_name:
+    ensure => absent,
+  }
+
+  package { $real_package_name:
+    ensure => installed,
+    require => Package[$::patterndb::params::default_syslog_package_name],
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,21 @@
+#
+# == Class: patterndb::params
+#
+# Defines some variables based on the operating system
+#
+class patterndb::params {
+
+  case $::osfamily {
+    'RedHat': {
+      $syslog_ng_package_name = 'syslog-ng'
+      $default_syslog_package_name = 'rsyslog'
+    }
+    'Debian': {
+      $syslog_ng_package_name = 'syslog-ng'
+      $default_syslog_package_name = 'rsyslog'
+    }
+    default: {
+      fail("Unsupported operating system ${::osfamily}")
+    }
+  }
+}

--- a/manifests/parser.pp
+++ b/manifests/parser.pp
@@ -4,10 +4,10 @@ define patterndb::parser (
   $syslogng_modules = $::patterndb::syslogng_modules
 ) {
   if ! defined(Class['Patterndb']) {
-    include patterndb
+    include ::patterndb
   }
   if empty($syslogng_modules) {
-    $modules = ''
+    $modules = undef
   } else {
     $tmp = join($syslogng_modules,' --module=')
     $modules = "--module=${tmp}"

--- a/manifests/raw/ruleset.pp
+++ b/manifests/raw/ruleset.pp
@@ -16,7 +16,7 @@ define patterndb::raw::ruleset (
   validate_bool($recurse)
 
   if ! defined(Class['Patterndb']) {
-    include patterndb
+    include ::patterndb
   }
 
   if ! defined(Patterndb::Parser[$parser]) {

--- a/manifests/simple/ruleset.pp
+++ b/manifests/simple/ruleset.pp
@@ -11,7 +11,7 @@ define patterndb::simple::ruleset (
 ) {
 
   if ! defined(Class['Patterndb']) {
-    include patterndb
+    include ::patterndb
   }
 
   $patterns_a = string2array($patterns)

--- a/smoke/NOK_mismatching_action.pp
+++ b/smoke/NOK_mismatching_action.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_getent.pp
+++ b/smoke/OK_getent.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/',
   syslogng_modules => [ 'tfgetent' ]
 }

--- a/smoke/OK_hybrid.pp
+++ b/smoke/OK_hybrid.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_modules.pp
+++ b/smoke/OK_modules.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/',
   syslogng_modules => [ 'basicfuncs' ]
 }

--- a/smoke/OK_multiple_pdb.pp
+++ b/smoke/OK_multiple_pdb.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_notest.pp
+++ b/smoke/OK_notest.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/',
   syslogng_modules => [ 'pdbtool_test_would_fail_with_this_module' ],
   test_before_deploy => false

--- a/smoke/OK_raw.pp
+++ b/smoke/OK_raw.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/',
   syslogng_modules => ['tfgetent']
 }

--- a/smoke/OK_s.pp
+++ b/smoke/OK_s.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_separate_action.pp
+++ b/smoke/OK_separate_action.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_separate_rules.pp
+++ b/smoke/OK_separate_rules.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_separate_rules_and_actions.pp
+++ b/smoke/OK_separate_rules_and_actions.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_simple.pp
+++ b/smoke/OK_simple.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_simple_action.pp
+++ b/smoke/OK_simple_action.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_simple_coerce.pp
+++ b/smoke/OK_simple_coerce.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_simple_context.pp
+++ b/smoke/OK_simple_context.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_simple_empty.pp
+++ b/smoke/OK_simple_empty.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp/'
 }
 

--- a/smoke/OK_yum.pp
+++ b/smoke/OK_yum.pp
@@ -1,5 +1,5 @@
 #
-class { 'patterndb':
+class { '::patterndb':
   base_dir => '/tmp',
   syslogng_modules => [ 'tfgeoip', 'tfgetent' ],
   test_before_deploy => true,


### PR DESCRIPTION
Hi,

The first commit fixes some (trivial) puppet-lint warnings. From what I've read Puppet 4 does not allow references to relative class names, so "include patterdb" won't work, whereas "include ::patterndb" will. For this reason I fixed those.

Puppet-lint also complained about indentation; the resources are currently defined like this:

    resource { 'title':
      long_parameter_name => 'value',
      otherparam => 'value2',
    }

Whereas puppet-lint wants them to look like this:

    resource { 'title':
      long_parameter_name => 'value',
      otherparam          => 'value2',
    }

If you want, I can trivially fix these indentation issues also.

The second commit's primary purpose is to fix installation of syslog-ng on Ubuntu 14.04. It is quite likely that installation was broken on other Debian derivatives also. The commit message contains hopefully adequate explanation of what was done and why.