### PR TITLE
Ensure syslog-ng-core is installed on Debian

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@ class patterndb (
     } else {
       case $::osfamily {
         'RedHat': { $real_package_name = 'syslog-ng' }
-        'Debian': { $real_package_name = 'syslog-ng' }
+        'Debian': { $real_package_name = 'syslog-ng-core' }
         default: { fail("unsupported osfamily: ${::osfamily}") }
       }
     }

--- a/spec/classes/patterndb_spec.rb
+++ b/spec/classes/patterndb_spec.rb
@@ -4,9 +4,6 @@ oses_specs = @oses_specs
 
 describe 'patterndb', :type => 'class' do
   oses_specs.each do |osname, specs|
-    let :package_name do
-      specs[:syslog_ng_package]
-    end
     context "#{osname} OS without package_name" do
       let :facts do {
           :osfamily        => specs[:osfamily],
@@ -14,7 +11,7 @@ describe 'patterndb', :type => 'class' do
       }
       end
       it {
-        should contain_package(package_name)
+        should contain_package(specs[:syslog_ng_package])
       }
     end
     context "#{osname} OS without managing package" do
@@ -22,7 +19,7 @@ describe 'patterndb', :type => 'class' do
         { :manage_package => false }
       end
       it {
-        should_not contain_package(package_name)
+        should_not contain_package(specs[:syslog_ng_package])
       }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,7 @@ end
         :operatingsystem            => 'Debian',
         :osfamily                   => 'Debian',
 
-        :syslog_ng_package          => 'syslog-ng',
+        :syslog_ng_package          => 'syslog-ng-core',
     }),
 }
 


### PR DESCRIPTION
On Debian, the syslog-ng package is a meta-package that recommands all
other syslog-ng-* packages but does not provide any feature:
  - https://packages.debian.org/jessie/all/syslog-ng/filelist
  - https://packages.debian.org/stretch/all/syslog-ng/filelist
  - https://packages.debian.org/buster/all/syslog-ng/filelist

Change the dependency to only ensure syslog-ng-core is installed.