### PR TITLE
Fix duplicate resource declaration issue

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class patterndb (
         default: { fail("unsupported osfamily: ${::osfamily}") }
       }
     }
-    ensure_resource ( 'package', $real_package_name, { 'ensure' => 'installed' })
+    ensure_packages ( $real_package_name, { 'ensure' => 'installed' })
   }
   ensure_resource ( 'file', $temp_dir, { ensure => directory } )
   if $_manage_top_dirs {


### PR DESCRIPTION
According to the documentation of `ensure_resource()` of stdlib:

> If the resource already exists, but does not match the specified
> parameters, this function attempts to recreate the resource, leading
> to a duplicate resource definition error.

It happens that the puppet-syslog_ng module does declare the same
resource with different (meta-)parameters:

https://github.com/ccin2p3/puppet-syslog_ng/blob/master/manifests/init.pp#L28-L34

As a consequence, the catalog fails to compile:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Duplicate declaration: Package[syslog-ng-core] is already declared at (file: /etc/puppetlabs/code/environments/romain/modules/syslog_ng/manifests/init.pp, line: 28); cannot redeclare (file: /etc/puppetlabs/code/environments/romain/modules/patterndb/manifests/init.pp, line: 23) (file: /etc/puppetlabs/code/environments/romain/modules/patterndb/manifests/init.pp, line: 23, column: 5) on node ns3745003.ip-213-32-0.eu
```

The `ensure_packages()` function does not suffer from this, so rely on it
instead of `ensure_resource()`.