### PR TITLE
Drop Debian 9 (EOL)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@ class patterndb (
 ) {
 # package
   if $manage_package {
-    if is_string($package_name) {
+    if $package_name =~ String {
       $real_package_name = $package_name
     } else {
       case $facts['os']['family'] {

--- a/manifests/simple/ruleset.pp
+++ b/manifests/simple/ruleset.pp
@@ -5,7 +5,7 @@ define patterndb::simple::ruleset (
   Array[String[1]] $patterns    = [],
   Array[Patterndb::Rule] $rules = [],
   String[1] $parser             = 'default',
-  Integer $version              = if versioncmp($facts['syslog_ng_version'], '4.0.0') >= 0 {
+  Integer $version              = if versioncmp($facts.get('syslog_ng_version', '3.0.0'), '4.0.0') >= 0 {
     6
   } else {
     4

--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
         "10",
         "11"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
   "author": "ccin2p3",
   "summary": "Puppet module for patterndb (Syslog-ng)",
   "license": "CECILL-B",
-  "source": "git://github.com/ccin2p3/puppet-patterndb.git",
+  "source": "https://github.com/ccin2p3/puppet-patterndb.git",
   "project_page": "https://github.com/ccin2p3/puppet-patterndb",
   "issues_url": "https://github.com/ccin2p3/puppet-patterndb/issues",
   "dependencies": [

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -10,7 +10,7 @@ configure_beaker do |host|
   install_package(host, 'lsb-release') if fact_on(host, 'os.name') == 'Ubuntu'
 
   install_module_from_forge_on(host, 'ccin2p3/syslog_ng', '>= 0')
-  install_module_from_forge_on(host, 'puppetlabs/apt', '>= 0')
+  install_module_from_forge_on(host, 'puppetlabs/apt', '>= 0 < 9.0.0')
   install_module_from_forge_on(host, 'puppet/epel', '>= 0')
 end
 


### PR DESCRIPTION
This PR also include #35.

Debian 9 has reached EOL (and enterred ELTS support).  It's dead.  Get rid of it and enjoy a green CI.

![](https://media.giphy.com/media/B8P2DKq8lKbuM/giphy.gif)