### PR TITLE
Fix emission of empty ACTIONS tag

### DIFF
--- a/templates/rule-footer.erb
+++ b/templates/rule-footer.erb
@@ -1,2 +1,4 @@
+<% if ! @actions.empty? -%>
 				</actions>
+<% end -%>
 			</rule>

--- a/templates/rule-header.erb
+++ b/templates/rule-header.erb
@@ -44,4 +44,6 @@
 <% end -%>
 				</examples>
 <% end -%>
+<% if ! @actions.empty? -%>
 				<actions>
+<% end -%>


### PR DESCRIPTION
The latest version of the patterndb schema fail validation if an ACTIONS
tag has no ACTION tag in it.  Ensure we do not produce such a tag when
it is not needed.

Fixes #3
