### PR TITLE
Do not remove existing merged parser before testing a new one

### DIFF
--- a/manifests/parser.pp
+++ b/manifests/parser.pp
@@ -31,7 +31,7 @@ define patterndb::parser (
   }
 
   $deploy_command = if $test_before_deploy.lest || { $patterndb::test_before_deploy } {
-    "rm -f ${patterndb::var_dir}/patterndb/${name}.xml && pdbtool test ${patterndb::cache_dir}/patterndb/${name}.xml ${modules} && cp ${patterndb::cache_dir}/patterndb/${name}.xml ${patterndb::var_dir}/patterndb/${name}.xml"
+    "pdbtool test ${patterndb::cache_dir}/patterndb/${name}.xml ${modules} && cp ${patterndb::cache_dir}/patterndb/${name}.xml ${patterndb::var_dir}/patterndb/${name}.xml"
   } else {
     "cp ${patterndb::cache_dir}/patterndb/${name}.xml ${patterndb::var_dir}/patterndb/${name}.xml"
   }

--- a/spec/defines/parser_spec.rb
+++ b/spec/defines/parser_spec.rb
@@ -37,7 +37,7 @@ describe 'patterndb::parser', type: 'define' do
 
         it {
           is_expected.to contain_exec('patterndb::deploy::default').with(
-            'command' => "rm -f #{vardir}/patterndb/default.xml && pdbtool test /var/cache/syslog-ng/patterndb/default.xml  && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml"
+            'command' => "pdbtool test /var/cache/syslog-ng/patterndb/default.xml  && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml"
           )
         }
       end
@@ -51,7 +51,7 @@ describe 'patterndb::parser', type: 'define' do
 
         it {
           is_expected.to contain_exec('patterndb::deploy::default').with(
-            'command' => "rm -f #{vardir}/patterndb/default.xml && pdbtool test /var/cache/syslog-ng/patterndb/default.xml --module=foo --module=bar && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml"
+            'command' => "pdbtool test /var/cache/syslog-ng/patterndb/default.xml --module=foo --module=bar && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml"
           )
         }
       end
@@ -63,13 +63,13 @@ describe 'patterndb::parser', type: 'define' do
 
         it {
           is_expected.to contain_exec('patterndb::deploy::default').with(
-            'command' => "rm -f #{vardir}/patterndb/default.xml && pdbtool test /var/cache/syslog-ng/patterndb/default.xml  && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml"
+            'command' => "pdbtool test /var/cache/syslog-ng/patterndb/default.xml  && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml"
           )
         }
 
         it {
           is_expected.to contain_exec('patterndb::deploy::stage1').with(
-            'command' => "rm -f #{vardir}/patterndb/stage1.xml && pdbtool test /var/cache/syslog-ng/patterndb/stage1.xml  && cp /var/cache/syslog-ng/patterndb/stage1.xml #{vardir}/patterndb/stage1.xml"
+            'command' => "pdbtool test /var/cache/syslog-ng/patterndb/stage1.xml  && cp /var/cache/syslog-ng/patterndb/stage1.xml #{vardir}/patterndb/stage1.xml"
           )
         }
       end
@@ -82,7 +82,7 @@ describe 'patterndb::parser', type: 'define' do
 
         it {
           is_expected.to contain_exec('patterndb::deploy::default').with(
-            'command' => "rm -f #{vardir}/patterndb/default.xml && pdbtool test /var/cache/syslog-ng/patterndb/default.xml --module=foo --module=bar && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml"
+            'command' => "pdbtool test /var/cache/syslog-ng/patterndb/default.xml --module=foo --module=bar && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml"
           )
         }
       end
@@ -94,7 +94,7 @@ describe 'patterndb::parser', type: 'define' do
 
         it {
           is_expected.to contain_exec('patterndb::deploy::default').with(
-            'command' => "rm -f #{vardir}/patterndb/default.xml && pdbtool test /var/cache/syslog-ng/patterndb/default.xml  && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml"
+            'command' => "pdbtool test /var/cache/syslog-ng/patterndb/default.xml  && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml"
           )
         }
       end
@@ -116,7 +116,7 @@ describe 'patterndb::parser', type: 'define' do
           }
         end
 
-        it { is_expected.to contain_exec('patterndb::deploy::default').with(command: "rm -f #{vardir}/patterndb/default.xml && pdbtool test /var/cache/syslog-ng/patterndb/default.xml  && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml") }
+        it { is_expected.to contain_exec('patterndb::deploy::default').with(command: "pdbtool test /var/cache/syslog-ng/patterndb/default.xml  && cp /var/cache/syslog-ng/patterndb/default.xml #{vardir}/patterndb/default.xml") }
       end
     end
   end


### PR DESCRIPTION
When updating a working parser with one that does not pass tests, the old parser was removed and syslog-ng started to complain that it could not process logs through this parser, causing a lot of noise in the logs:

```
Error stating pattern database file, no automatic reload will be performed; file='/var/lib/syslog-ng/patterndb/default.xml', error='No such file or directory', location='/etc/syslog-ng/syslog-ng.conf:97:5'
Error stating pattern database file, no automatic reload will be performed; file='/var/lib/syslog-ng/patterndb/default.xml', error='No such file or directory', location='/etc/syslog-ng/syslog-ng.conf:97:5'
Error stating pattern database file, no automatic reload will be performed; file='/var/lib/syslog-ng/patterndb/default.xml', error='No such file or directory', location='/etc/syslog-ng/syslog-ng.conf:97:5'
Error stating pattern database file, no automatic reload will be performed; file='/var/lib/syslog-ng/patterndb/default.xml', error='No such file or directory', location='/etc/syslog-ng/syslog-ng.conf:97:5'
Error stating pattern database file, no automatic reload will be performed; file='/var/lib/syslog-ng/patterndb/default.xml', error='No such file or directory', location='/etc/syslog-ng/syslog-ng.conf:97:5'
```

Because we test and copy the parser only when the used parser is older than the merged one, we do not need to remove it first.  If not up-to-date, the test and copy is run, if the test fail the old version is kept in place and another attempt will occur on the next Puppet run.